### PR TITLE
build: run packer tart image builds headlessly

### DIFF
--- a/packer/macos-base.pkr.hcl
+++ b/packer/macos-base.pkr.hcl
@@ -16,6 +16,7 @@ source "tart-cli" "macos-base" {
   cpu_count    = 4
   memory_gb    = 8
   disk_size_gb = 80
+  headless     = true
 
   ssh_username = "admin"
   ssh_password = "admin"


### PR DESCRIPTION
## Summary

Set the Tart Packer source to headless mode in `packer/macos-base.pkr.hcl` by adding:
- `headless = true`

Why:

- `clawbox image build` should not open a VM window during base image creation.
- This makes image builds quieter and better suited for unattended runs.

## Validation

- [X] Ran `./scripts/ci/run.sh fast`
- [X] Ran `./scripts/ci/run.sh logic`
- [X] Ran `./scripts/ci/run.sh integration` (if macOS + Tart environment was available)
- [X] Ran `clawbox image build` and confirmed no VM UI window appears