### PR TITLE
fix(integration): remove stale provision markers during cleanup

### DIFF
--- a/tests/integration_py/run_integration.py
+++ b/tests/integration_py/run_integration.py
@@ -97,6 +97,7 @@ class IntegrationRunner:
     def cleanup_vm(self, vm_name: str) -> None:
         self.run_cmd(["tart", "stop", vm_name], check=False, capture_output=True)
         self.run_cmd(["tart", "delete", vm_name], check=False, capture_output=True)
+        self.marker_path(vm_name).unlink(missing_ok=True)
 
     def cleanup_all(self) -> None:
         for vm_name in {self.standard_vm_name, self.developer_vm_name, self.optional_vm_name}:


### PR DESCRIPTION
## Title
Fix integration teardown to remove stale `.provisioned` markers

## Summary
Integration cleanup removed Tart VMs but could leave local provision marker files behind.
This caused `clawbox status` to report integration VM numbers (for example `clawbox-92`) as discovered with `exists: no` and `provision
marker: present`.

## Root Cause
`IntegrationRunner.cleanup_vm()` in `tests/integration_py/run_integration.py` only performed:
- `tart stop <vm>`
- `tart delete <vm>`

It did not remove `project/.clawbox/state/<vm>.provisioned`.

## Changes
- Updated `cleanup_vm()` to also remove the marker file:
- `self.marker_path(vm_name).unlink(missing_ok=True)`
- Added regression tests in `tests/logic_py/test_integration_cleanup.py`:
- `test_cleanup_vm_removes_marker`
- `test_cleanup_all_removes_all_markers`

## Validation
- `python3 -m pytest -q tests/logic_py/test_integration_cleanup.py`
- Result: `9 passed`

## Notes
When `CLAWBOX_CI_KEEP_FAILURE_ARTIFACTS=true`, failure artifacts are still intentionally preserved by main cleanup policy.