### PR TITLE
build: exclude `dist/` from bidirectional sync

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -58,6 +58,13 @@ Developer sync readiness:
 2. Treat `Clawbox is ready: <vm-name>` as the interaction-safe point for login and synced path edits.
 3. On slower hosts, increase wait time with `CLAWBOX_MUTAGEN_READY_TIMEOUT_SECONDS` (default: `60`).
 
+Source-driven gateway loop (run inside VM):
+
+```bash
+cd ~/Developer/openclaw
+pnpm gateway:watch
+```
+
 ## Command Flows
 
 Recommended entrypoint:

--- a/README.md
+++ b/README.md
@@ -104,12 +104,15 @@ clawbox up --developer --number 2 \
 
 > **Note:** Apple's macOS Software License Agreement permits up to two virtualized macOS instances per Apple host. Clawbox can target other VM numbers, but host virtualization limits may block additional concurrent VMs.
 
-For source-driven dev loops, combine with OpenClaw's documented file watcher flow:
+For source-driven dev loops in a Clawbox VM, run this inside the VM:
 
 ```bash
 cd ~/Developer/openclaw
-pnpm gateway:watch --force
+pnpm gateway:watch
 ```
+
+Then edit files on the host in the synced source checkout (for example, `~/Developer/openclaw-1`).
+Clawbox excludes `dist` from source sync so build artifacts stay VM-local while source changes still hot-reload.
 
 ## Optional Dependency Provisioning
 

--- a/clawbox/orchestrator.py
+++ b/clawbox/orchestrator.py
@@ -225,7 +225,7 @@ SYNC_PATH_BINDINGS = (
         guest_path_template=OPENCLAW_SOURCE_MOUNT,
         default_guest_path_template=DEFAULT_OPENCLAW_SOURCE_MOUNT,
         ignore_vcs=True,
-        ignored_paths=("node_modules",),
+        ignored_paths=("node_modules", "dist"),
         required=True,
     ),
     SyncPathBinding(

--- a/tests/integration_py/run_integration.py
+++ b/tests/integration_py/run_integration.py
@@ -409,11 +409,15 @@ class IntegrationRunner:
                 """\
                 #!/usr/bin/env node
 
+                const fs = require('node:fs')
+                const path = require('node:path')
                 const args = process.argv.slice(2)
                 if (args.includes('--help')) {
                   console.log('openclaw gateway:watch fixture help')
                   process.exit(0)
                 }
+                const marker = path.join(process.cwd(), '.clawbox-gateway-watch-invoked')
+                fs.writeFileSync(marker, `${args.join(' ')}\\n`, 'utf8')
                 console.log('openclaw gateway:watch fixture invoked:', args.join(' '))
                 process.exit(0)
                 """
@@ -839,7 +843,13 @@ class IntegrationRunner:
             "--dir",
             f"/Users/{self.developer_vm_name}/Developer/openclaw",
             "gateway:watch",
-            "--help",
+        )
+        self.assert_remote_test(
+            self.developer_vm_name,
+            (
+                "test -f "
+                f"'/Users/{self.developer_vm_name}/Developer/openclaw/.clawbox-gateway-watch-invoked'"
+            ),
         )
 
     def run_optional_feature_flow(self) -> None:

--- a/tests/logic_py/test_docs.py
+++ b/tests/logic_py/test_docs.py
@@ -22,6 +22,15 @@ def test_readme_and_developer_guide_define_orchestration_only_contract() -> None
     assert "clawbox recreate 1" in guide
 
 
+def test_readme_uses_gateway_watch_without_redundant_force_flag() -> None:
+    readme = (PROJECT_DIR / "README.md").read_text(encoding="utf-8")
+    guide = (PROJECT_DIR / "DEVELOPER.md").read_text(encoding="utf-8")
+    assert "pnpm gateway:watch\n" in readme
+    assert "pnpm gateway:watch --force" not in readme
+    assert "pnpm gateway:watch\n" in guide
+    assert "pnpm gateway:watch --force" not in guide
+
+
 def test_openclaw_role_links_developer_source_without_runtime_wrappers() -> None:
     role = (PROJECT_DIR / "ansible" / "roles" / "openclaw" / "tasks" / "main.yml").read_text(
         encoding="utf-8"

--- a/tests/logic_py/test_orchestrator_edges.py
+++ b/tests/logic_py/test_orchestrator_edges.py
@@ -617,7 +617,7 @@ def test_deactivate_mutagen_sync_maps_mutagen_error(monkeypatch: pytest.MonkeyPa
         orchestrator._deactivate_mutagen_sync("clawbox-1", flush=False)
 
 
-def test_build_sync_specs_ignores_node_modules_for_source() -> None:
+def test_build_sync_specs_ignores_node_modules_and_dist_for_source() -> None:
     specs = orchestrator._build_sync_specs(
         "clawbox-1",
         {
@@ -628,7 +628,7 @@ def test_build_sync_specs_ignores_node_modules_for_source() -> None:
     )
     source_specs = [spec for spec in specs if spec.kind == "openclaw-source"]
     assert len(source_specs) == 1
-    assert source_specs[0].ignored_paths == ("node_modules",)
+    assert source_specs[0].ignored_paths == ("node_modules", "dist")
     assert source_specs[0].ready_required is True
     signal_specs = [spec for spec in specs if spec.kind == "signal-payload"]
     assert len(signal_specs) == 0


### PR DESCRIPTION
## Summary

This PR excludes `dist/` from Mutagen syncing. The contents of `dist/` are build artifacts, which should remain VM local.

## Validation

- [X] Ran `./scripts/ci/run.sh fast`
- [X] Ran `./scripts/ci/run.sh logic`
- [X] Ran `./scripts/ci/run.sh integration` (if macOS + Tart environment was available)
