### PR TITLE
chore: improve gateway behavior + README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For source-driven dev loops in a Clawbox VM, run this inside the VM:
 
 ```bash
 cd ~/Developer/openclaw
-pnpm gateway:watch
+node --watch-path src --watch-path tsconfig.json --watch-path package.json --watch-preserve-output scripts/run-node.mjs gateway --force
 ```
 
 Then edit files on the host in the synced source checkout (for example, `~/Developer/openclaw-1`).

--- a/ansible/roles/homebrew/tasks/main.yml
+++ b/ansible/roles/homebrew/tasks/main.yml
@@ -18,6 +18,19 @@
     line: 'eval "$(/opt/homebrew/bin/brew shellenv)"'
     create: yes
 
+- name: Ensure Homebrew is on PATH for non-login zsh shells
+  become: true
+  blockinfile:
+    path: /etc/zshenv
+    create: true
+    marker: "# {mark} CLAWBOX HOMEBREW PATH"
+    block: |
+      # Ensure Homebrew tools are available in non-login zsh shells.
+      case ":$PATH:" in
+        *:/opt/homebrew/bin:*) ;;
+        *) export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH" ;;
+      esac
+
 - name: Ensure Mutagen Homebrew tap is available
   become_user: "{{ vm_name }}"
   command: /opt/homebrew/bin/brew tap mutagen-io/mutagen

--- a/tests/logic_py/test_docs.py
+++ b/tests/logic_py/test_docs.py
@@ -22,10 +22,13 @@ def test_readme_and_developer_guide_define_orchestration_only_contract() -> None
     assert "clawbox recreate 1" in guide
 
 
-def test_readme_uses_gateway_watch_without_redundant_force_flag() -> None:
+def test_readme_uses_clawbox_safe_watch_recipe() -> None:
     readme = (PROJECT_DIR / "README.md").read_text(encoding="utf-8")
     guide = (PROJECT_DIR / "DEVELOPER.md").read_text(encoding="utf-8")
-    assert "pnpm gateway:watch\n" in readme
+    assert "scripts/run-node.mjs gateway --force" in readme
+    assert "--watch-path src --watch-path tsconfig.json --watch-path package.json" in readme
+    assert "PATH=/opt/homebrew/bin:$PATH" not in readme
+    assert "pnpm gateway:watch\n" not in readme
     assert "pnpm gateway:watch --force" not in readme
     assert "pnpm gateway:watch\n" in guide
     assert "pnpm gateway:watch --force" not in guide
@@ -40,6 +43,18 @@ def test_openclaw_role_links_developer_source_without_runtime_wrappers() -> None
     assert "Link synced OpenClaw source as global openclaw command" in role
     assert "command: npm link" in role
     assert "openclaw-dev" not in role
+
+
+def test_homebrew_role_sets_path_for_login_and_non_login_zsh_shells() -> None:
+    role = (PROJECT_DIR / "ansible" / "roles" / "homebrew" / "tasks" / "main.yml").read_text(
+        encoding="utf-8"
+    )
+    assert 'path: "/Users/{{ vm_name }}/.zprofile"' in role
+    assert 'line: \'eval "$(/opt/homebrew/bin/brew shellenv)"\'' in role
+    assert "Ensure Homebrew is on PATH for non-login zsh shells" in role
+    assert "path: /etc/zshenv" in role
+    assert "CLAWBOX HOMEBREW PATH" in role
+    assert "/opt/homebrew/bin:/opt/homebrew/sbin:$PATH" in role
 
 
 def test_development_plan_references_python_cli_not_legacy_shell_wrappers() -> None:


### PR DESCRIPTION
## Summary

This PR makes changes align developer workflow docs and shell PATH behavior:

1. Updates README’s source-driven dev-loop command to the Clawbox-safe watcher recipe:
`node --watch-path src --watch-path tsconfig.json --watch-path package.json --watch-preserve-output scripts/run-node.mjs gateway --force`
2. Ensures Homebrew is available in non-login zsh shells by adding a managed `/etc/zshenv` PATH block in provisioning.
4. Expands logic tests to lock in:
- README uses the safe watcher recipe.
- README does not include the PATH-prefix fallback.
- Homebrew role configures both login (~/.zprofile) and non-login (/etc/zshenv) zsh PATH behavior.

## Validation

- [X] Ran `./scripts/ci/run.sh fast`
- [X] Ran `./scripts/ci/run.sh logic`
- [X] Ran `./scripts/ci/run.sh integration` (if macOS + Tart environment was available)