### PR TITLE
fix(provision): harden SSH auth and sync path ownership

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -7,4 +7,4 @@ interpreter_python = auto_silent
 
 [ssh_connection]
 pipelining = True
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o IdentitiesOnly=yes -o PubkeyAuthentication=no -o PreferredAuthentications=password,keyboard-interactive -o NumberOfPasswordPrompts=1

--- a/ansible/roles/network_preflight/tasks/main.yml
+++ b/ansible/roles/network_preflight/tasks/main.yml
@@ -143,7 +143,9 @@
   register: network_preflight_dns_resolution_after_fallback
   changed_when: false
   failed_when: false
-  when: network_preflight_dns_fallback_apply is defined and network_preflight_dns_fallback_apply.rc == 0
+  when: >-
+    network_preflight_dns_fallback_apply is defined and
+    (network_preflight_dns_fallback_apply.rc | default(1)) == 0
 
 - name: Choose effective DNS probe result
   set_fact:
@@ -161,7 +163,7 @@
         servers: {{ (clawbox_guest_dns_fallback_servers | default(['1.1.1.1', '8.8.8.8'])) | join(', ') }}
   when: >-
     network_preflight_dns_fallback_apply is defined and
-    network_preflight_dns_fallback_apply.rc == 0 and
+    (network_preflight_dns_fallback_apply.rc | default(1)) == 0 and
     network_preflight_dns_resolution_effective.rc == 0 and
     (network_preflight_dns_resolution_effective.stdout | trim | length) > 0
 

--- a/ansible/roles/openclaw/tasks/main.yml
+++ b/ansible/roles/openclaw/tasks/main.yml
@@ -49,6 +49,17 @@
     PATH: "{{ clawbox_brew_env_path }}"
   when: clawbox_profile == 'developer'
 
+- name: Ensure OpenClaw source tree ownership before dependency install
+  become: true
+  file:
+    path: "{{ openclaw_source_mount }}"
+    owner: "{{ vm_name }}"
+    group: staff
+    recurse: true
+    follow: false
+    state: directory
+  when: clawbox_profile == 'developer'
+
 - name: Install OpenClaw source dependencies
   become_user: "{{ vm_name }}"
   command: pnpm install --frozen-lockfile

--- a/clawbox/ansible_exec.py
+++ b/clawbox/ansible_exec.py
@@ -6,6 +6,13 @@ from pathlib import Path
 
 from clawbox.errors import UserFacingError
 
+PASSWORD_AUTH_SSH_COMMON_ARGS = (
+    "-o IdentitiesOnly=yes "
+    "-o PubkeyAuthentication=no "
+    "-o PreferredAuthentications=password,keyboard-interactive "
+    "-o NumberOfPasswordPrompts=1"
+)
+
 
 def build_ansible_shell_command(
     *,
@@ -35,6 +42,7 @@ def build_ansible_shell_command(
         f"ansible_password={ansible_password}",
         "-e",
         f"ansible_command_timeout={command_timeout_seconds}",
+        f"--ssh-common-args={PASSWORD_AUTH_SSH_COMMON_ARGS}",
         "-e",
         "ansible_become=false",
     ]

--- a/tests/logic_py/test_ansible_exec.py
+++ b/tests/logic_py/test_ansible_exec.py
@@ -22,6 +22,13 @@ def test_build_ansible_shell_command_defaults() -> None:
         become=False,
     )
     assert cmd[:6] == ["ansible", "-i", "192.168.64.10,", "clawbox-91", "-T", "8"]
+    ssh_args = (
+        "-o IdentitiesOnly=yes "
+        "-o PubkeyAuthentication=no "
+        "-o PreferredAuthentications=password,keyboard-interactive "
+        "-o NumberOfPasswordPrompts=1"
+    )
+    assert f"--ssh-common-args={ssh_args}" in cmd
     assert "ansible_become=false" in cmd
     assert "-b" not in cmd
     assert "ansible_become=true" not in cmd


### PR DESCRIPTION
## Summary
This PR fixes a startup/provisioning failure chain seen during `clawbox up --developer`.

## Root Cause
- SSH connections during bootstrap/provisioning could hit `Too many authentication failures` when host SSH agents offered many identities before password auth.
- DNS fallback logic in `network_preflight` assumed `rc` always exists for a registered task result, which is false when that task is skipped.
- Under Mutagen developer sync, files in the synced OpenClaw source path could be owned by the bootstrap user, causing `pnpm install` to fail with `EACCES`.

## Changes
- Force Ansible shell probes to pass explicit SSH common args that disable pubkey auth/extra identities and prefer password auth.
- Apply equivalent SSH hardening in `ansible/ansible.cfg` so `ansible-playbook` uses consistent auth behavior.
- Guard DNS fallback `when` conditionals with `| default(1)` for `rc` access on possibly skipped task results.
- Ensure OpenClaw source sync path ownership is corrected to the VM user before dependency installation.
- Add/update unit coverage for the Ansible shell command shape.

## Validation
- `python3 -m pytest -q tests/logic_py` -> `272 passed`
- Reproduced end-to-end with:
  - `clawbox delete 1`
  - `clawbox up --developer --number 1 --openclaw-source ~/Developer/openclaw-1 --openclaw-payload ~/Developer/openclaw-payloads/openclaw/1 --add-signal-cli-provisioning --signal-cli-payload ~/Developer/openclaw-payloads/signal-cli/J2_D2`
- Final run completed with `Clawbox is ready: clawbox-1`.
