### PR TITLE
fix(network_preflight): guard skipped fallback DNS probe result

### DIFF
--- a/ansible/roles/network_preflight/tasks/main.yml
+++ b/ansible/roles/network_preflight/tasks/main.yml
@@ -151,7 +151,11 @@
   set_fact:
     network_preflight_dns_resolution_effective: >-
       {{ network_preflight_dns_resolution_after_fallback
-         if (network_preflight_dns_resolution_after_fallback is defined)
+         if (
+           network_preflight_dns_resolution_after_fallback is defined and
+           not (network_preflight_dns_resolution_after_fallback.skipped | default(false) | bool) and
+           (network_preflight_dns_resolution_after_fallback.rc is defined)
+         )
          else network_preflight_dns_resolution }}
 
 - name: Confirm DNS fallback succeeded

--- a/tests/logic_py/test_docs.py
+++ b/tests/logic_py/test_docs.py
@@ -92,6 +92,8 @@ def test_network_preflight_has_guest_dns_fallback_step() -> None:
     assert "Fail fast when DNS remains unavailable after fallback" in role
     assert "Check HTTPS reachability for Homebrew installer endpoint" not in role
     assert "networksetup -setdnsservers" in role
+    assert "network_preflight_dns_resolution_after_fallback.rc is defined" in role
+    assert "network_preflight_dns_resolution_after_fallback.skipped | default(false) | bool" in role
 
 
 def test_development_plan_references_python_cli_not_legacy_shell_wrappers() -> None:


### PR DESCRIPTION
## Summary
- avoid selecting `network_preflight_dns_resolution_after_fallback` when the fallback probe task was skipped
- require a real fallback probe result (`rc` present) before using it as the effective DNS probe
- add a regression assertion in logic tests to keep this guard in place

## Root Cause
`network_preflight_dns_resolution_after_fallback` is still defined when its task is skipped, but that skipped result does not include `rc`. The previous selector treated "defined" as sufficient, and later conditionals accessed `.rc`, causing provisioning to fail during DNS preflight.

## Testing
- python3 -m pytest -q tests/logic_py/test_docs.py -k network_preflight
- python3 -m pytest -q tests/logic_py
